### PR TITLE
[WIP] Allow overrides

### DIFF
--- a/main.go
+++ b/main.go
@@ -226,6 +226,7 @@ func writeNodes(nodes []Node, overrides map[string]map[string]interface{}, port 
 	if err != nil {
 		return
 	}
+	os.MkdirAll(fmt.Sprintf("%s/conf.d", dir), 0755)
 	err = ioutil.WriteFile(fmt.Sprintf("%s/conf.d/prometheus-puppetdb.yml", dir), c, 0644)
 	if err != nil {
 		return
@@ -236,6 +237,7 @@ func writeNodes(nodes []Node, overrides map[string]map[string]interface{}, port 
 		return
 	}
 
+	os.MkdirAll(fmt.Sprintf("%s/targets/prometheus-puppetdb/", dir), 0755)
 	err = ioutil.WriteFile(file, d, 0644)
 	if err != nil {
 		return

--- a/main.go
+++ b/main.go
@@ -212,6 +212,25 @@ func writeNodes(nodes []Node, overrides map[string]map[string]interface{}, port 
 					{Files: []string{fmt.Sprintf("%s/targets/%s/*.yml", dir, node.Certname)}},
 				}
 				prometheusConfig.ScrapeConfigs = append(prometheusConfig.ScrapeConfigs, scrapeConfig)
+
+				var target = fmt.Sprintf("%s:%v", hostname, zeport)
+				targets.Targets = append(targets.Targets, target)
+				targets.Labels = map[string]string{
+					"job":      "collectd",
+					"certname": node.Certname,
+				}
+
+				d, err := yaml.Marshal([]Targets{targets})
+				if err != nil {
+					return err
+				}
+
+				os.MkdirAll(fmt.Sprintf("%s/targets/%s/", dir, node.Certname), 0755)
+				err = ioutil.WriteFile(fmt.Sprintf("%s/targets/%s/%s.yml", dir, node.Certname, node.Certname), d, 0644)
+				if err != nil {
+					return err
+				}
+				break
 			}
 		}
 		var target = fmt.Sprintf("%s:%v", hostname, zeport)

--- a/main.go
+++ b/main.go
@@ -177,6 +177,15 @@ func writeNodes(nodes []Node, overrides map[string]map[string]interface{}, port 
 
 	prometheusConfig := PrometheusConfig{}
 
+	prometheusConfig.ScrapeConfigs = append(
+		prometheusConfig.ScrapeConfigs,
+		ScrapeConfig{
+			JobName: "prometheus-puppetdb",
+			FileSdConfigs: []FileSdConfig{
+				{Files: []string{fmt.Sprintf("%s/targets/prometheus-puppetdb/*.yml", dir)}},
+			},
+		})
+
 	for _, node := range nodes {
 		var targets = Targets{}
 		var hostname = node.Ipaddress

--- a/main.go
+++ b/main.go
@@ -226,10 +226,20 @@ func writeNodes(nodes []Node, overrides map[string]map[string]interface{}, port 
 	if err != nil {
 		return
 	}
-	ioutil.WriteFile(fmt.Sprintf("%s/conf.d/prometheus-puppetdb.yml", dir), c, 0644)
+	err = ioutil.WriteFile(fmt.Sprintf("%s/conf.d/prometheus-puppetdb.yml", dir), c, 0644)
+	if err != nil {
+		return
+	}
 
 	d, err := yaml.Marshal(&allTargets)
+	if err != nil {
+		return
+	}
 
 	err = ioutil.WriteFile(file, d, 0644)
+	if err != nil {
+		return
+	}
+
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -191,6 +191,12 @@ func writeNodes(nodes []Node, overrides map[string]map[string]interface{}, port 
 		var hostname = node.Ipaddress
 		var zeport = port
 		if o, ok := overrides[node.Certname]; ok {
+			if h, ok := o["hostname"]; ok {
+				hostname = h.(string)
+			}
+			if p, ok := o["port"]; ok {
+				zeport = int(p.(float64))
+			}
 			scheme, okScheme := o["scheme"]
 			metricsPath, okMetricsPath := o["metrics_path"]
 			if okScheme || okMetricsPath {
@@ -206,12 +212,6 @@ func writeNodes(nodes []Node, overrides map[string]map[string]interface{}, port 
 					{Files: []string{fmt.Sprintf("%s/targets/%s/*.yml", dir, node.Certname)}},
 				}
 				prometheusConfig.ScrapeConfigs = append(prometheusConfig.ScrapeConfigs, scrapeConfig)
-			}
-			if h, ok := o["hostname"]; ok {
-				hostname = h.(string)
-			}
-			if p, ok := o["port"]; ok {
-				zeport = int(p.(float64))
 			}
 		}
 		var target = fmt.Sprintf("%s:%v", hostname, zeport)

--- a/main.go
+++ b/main.go
@@ -230,16 +230,24 @@ func writeNodes(nodes []Node, overrides map[string]map[string]interface{}, port 
 				if err != nil {
 					return err
 				}
-				break
+			} else {
+				var target = fmt.Sprintf("%s:%v", hostname, zeport)
+				targets.Targets = append(targets.Targets, target)
+				targets.Labels = map[string]string{
+					"job":      "collectd",
+					"certname": node.Certname,
+				}
+				allTargets = append(allTargets, targets)
 			}
+		} else {
+			var target = fmt.Sprintf("%s:%v", hostname, zeport)
+			targets.Targets = append(targets.Targets, target)
+			targets.Labels = map[string]string{
+				"job":      "collectd",
+				"certname": node.Certname,
+			}
+			allTargets = append(allTargets, targets)
 		}
-		var target = fmt.Sprintf("%s:%v", hostname, zeport)
-		targets.Targets = append(targets.Targets, target)
-		targets.Labels = map[string]string{
-			"job":      "collectd",
-			"certname": node.Certname,
-		}
-		allTargets = append(allTargets, targets)
 	}
 	c, err := yaml.Marshal(&prometheusConfig)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ type Config struct {
 	Query       string `short:"q" long:"puppetdb-query" description:"PuppetDB query." env:"PROMETHEUS_PUPPETDB_QUERY" default:"facts { name='ipaddress' and nodes { deactivated is null and ! (facts { name = 'osfamily' and value = 'RedHat' } and facts { name='operatingsystemmajrelease' and value = '5' }) and facts { name='collectd_version' and value ~ '^5\\\\.7' } and resources { type='Class' and title='Collectd' } } }"`
 	Port        int    `short:"p" long:"collectd-port" description:"Collectd port." env:"PROMETHEUS_PUPPETDB_COLLECTD_PORT" default:"9103"`
 	ConfigDir   string `short:"c" long:"config-dir" description:"Prometheus config dir." env:"PROMETHEUS_CONFIG_DIR" default:"/etc/prometheus"`
-	File        string `short:"f" long:"config-file" description:"Prometheus target file." env:"PROMETHEUS_PUPPETDB_FILE" default:"/etc/prometheus/targets/default/targets.yml"`
+	File        string `short:"f" long:"config-file" description:"Prometheus target file." env:"PROMETHEUS_PUPPETDB_FILE" default:"/etc/prometheus/targets/prometheus-puppetdb/targets.yml"`
 	Sleep       string `short:"s" long:"sleep" description:"Sleep time between queries." env:"PROMETHEUS_PUPPETDB_SLEEP" default:"5s"`
 	Manpage     bool   `short:"m" long:"manpage" description:"Output manpage."`
 }

--- a/main.go
+++ b/main.go
@@ -43,18 +43,18 @@ type Targets struct {
 }
 
 type FileSdConfig struct {
-	Files []string `yaml:"files"`
+	Files []string `yaml:"files,omitempty"`
 }
 
 type ScrapeConfig struct {
-	JobName       string         `yaml:"job_name"`
-	MetricsPath   string         `yaml:"metrics_path"`
-	Scheme        string         `yaml:"scheme"`
-	FileSdConfigs []FileSdConfig `yaml:"file_sd_configs"`
+	JobName       string         `yaml:"job_name,omitempty"`
+	MetricsPath   string         `yaml:"metrics_path,omitempty"`
+	Scheme        string         `yaml:"scheme,omitempty"`
+	FileSdConfigs []FileSdConfig `yaml:"file_sd_configs,omitempty"`
 }
 
 type PrometheusConfig struct {
-	ScrapeConfigs []ScrapeConfig `yaml:"scrape_configs"`
+	ScrapeConfigs []ScrapeConfig `yaml:"scrape_configs,omitempty"`
 }
 
 func main() {
@@ -188,13 +188,9 @@ func writeNodes(nodes []Node, overrides map[string]map[string]interface{}, port 
 				scrapeConfig.JobName = node.Certname
 				if okScheme {
 					scrapeConfig.Scheme = scheme.(string)
-				} else {
-					scrapeConfig.Scheme = "http"
 				}
 				if okMetricsPath {
 					scrapeConfig.MetricsPath = metricsPath.(string)
-				} else {
-					scrapeConfig.MetricsPath = "/metrics"
 				}
 				scrapeConfig.FileSdConfigs = []FileSdConfig{
 					{Files: []string{fmt.Sprintf("/etc/prometheus-targets/%s/*-targets.yaml", node.Certname)}},

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ var version = "undefined"
 type Config struct {
 	Version     bool   `short:"V" long:"version" description:"Display version."`
 	PuppetDBURL string `short:"u" long:"puppetdb-url" description:"PuppetDB base URL." env:"PROMETHEUS_PUPPETDB_URL" default:"http://puppetdb:8080"`
-	Query       string `short:"q" long:"puppetdb-query" description:"PuppetDB query." env:"PROMETHEUS_PUPPETDB_QUERY" default:"facts { name='ipaddress' and nodes { deactivated is null and ! (facts { name = 'osfamily' and value = 'RedHat' } and facts { name='operatingsystemmajrelease' and value = '5' }) and facts { name='collectd_version' and value ~ '^5\\\\.7' } and resources { type='Class' and title='Collectd' } } }"`
+	Query       string `short:"q" long:"puppetdb-query" description:"PuppetDB query." env:"PROMETHEUS_PUPPETDB_QUERY" default:"facts[certname, value] { name='ipaddress' and nodes { deactivated is null } }"`
 	Port        int    `short:"p" long:"collectd-port" description:"Collectd port." env:"PROMETHEUS_PUPPETDB_COLLECTD_PORT" default:"9103"`
 	ConfigDir   string `short:"c" long:"config-dir" description:"Prometheus config dir." env:"PROMETHEUS_CONFIG_DIR" default:"/etc/prometheus"`
 	File        string `short:"f" long:"config-file" description:"Prometheus target file." env:"PROMETHEUS_PUPPETDB_FILE" default:"/etc/prometheus/targets/prometheus-puppetdb/targets.yml"`


### PR DESCRIPTION
We want to be able to use the `prometheus_target_conf` structured fact to override stuffs locally.

For example, we want to able to do have this kind of override:
```json
{
  "scheme": "https",
  "hostname": "foo.example.com",
  "port": "443",
  "metrics_path": "/fooBar"
}
```
The problem is that `hostname` and `port` are configured in the `file_sd_config`, but the `scheme` and `metrics_path` are configured in `scrape_config` level. So, we have to generate some prometheus configuration snippets that will be aggregated by another process that will reload the prometheus server.

The configuration snippet we'd like to have is:
```yaml
scrape_configs:
- job_name: <certname>
  scheme: https
  metrics_path: /fooBar
  file_sd_configs:
  - files:
    - /etc/prometheus-targets/<job_name>/targets.yml
```
With a `/etc/prometheus-targets/<certname>/targets.yml` file containing:
```yaml
- targets:
  - foo.example.com:443
```