### PR TITLE
Support client TLS auth for secured PuppetDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+prometheus-puppetdb

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 prometheus-puppetdb
+certs

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 )
 
 var version = "undefined"
+var transport *http.Transport
 
 type Config struct {
 	Version       bool   `short:"V" long:"version" description:"Display version."`
@@ -83,7 +84,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	var transport *http.Transport
 	if puppetdbURL.Scheme == "https" {
 		// Load client cert
 		cert, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)

--- a/main.go
+++ b/main.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"crypto/tls"
+	"crypto/x509"
 	"os"
 	"strings"
 	"time"
@@ -18,14 +20,18 @@ import (
 var version = "undefined"
 
 type Config struct {
-	Version     bool   `short:"V" long:"version" description:"Display version."`
-	PuppetDBURL string `short:"u" long:"puppetdb-url" description:"PuppetDB base URL." env:"PROMETHEUS_PUPPETDB_URL" default:"http://puppetdb:8080"`
-	Query       string `short:"q" long:"puppetdb-query" description:"PuppetDB query." env:"PROMETHEUS_PUPPETDB_QUERY" default:"facts[certname, value] { name='ipaddress' and nodes { deactivated is null } }"`
-	Port        int    `short:"p" long:"collectd-port" description:"Collectd port." env:"PROMETHEUS_PUPPETDB_COLLECTD_PORT" default:"9103"`
-	ConfigDir   string `short:"c" long:"config-dir" description:"Prometheus config dir." env:"PROMETHEUS_CONFIG_DIR" default:"/etc/prometheus"`
-	File        string `short:"f" long:"config-file" description:"Prometheus target file." env:"PROMETHEUS_PUPPETDB_FILE" default:"/etc/prometheus/targets/prometheus-puppetdb/targets.yml"`
-	Sleep       string `short:"s" long:"sleep" description:"Sleep time between queries." env:"PROMETHEUS_PUPPETDB_SLEEP" default:"5s"`
-	Manpage     bool   `short:"m" long:"manpage" description:"Output manpage."`
+	Version     	bool   `short:"V" long:"version" description:"Display version."`
+	PuppetDBURL 	string `short:"u" long:"puppetdb-url" description:"PuppetDB base URL." env:"PROMETHEUS_PUPPETDB_URL" default:"http://puppetdb:8080"`
+	CertFile			string `short:"x" long:"cert-file" description:"A PEM eoncoded certificate file." env:"PROMETHEUS_CERT_FILE" default:"certs/client.pem"`
+	KeyFile				string `short:"y" long:"key-file" description:"A PEM eoncoded private key file." env:"PROMETHEUS_KEY_FILE" default:"certs/client.key"`
+	CACertFile		string `short:"z" long:"cacert-file" description:"A PEM eoncoded CA's certificate file." env:"PROMETHEUS_CACERT_FILE" default:"certs/cacert.pem"`
+	SSLSkipVerify	bool   `short:"k" long:"ssl-skip-verify" description:"Skip SSL verification." env:"PROMETHEUS_SSL_SKIP_VERIFY"`
+	Query       	string `short:"q" long:"puppetdb-query" description:"PuppetDB query." env:"PROMETHEUS_PUPPETDB_QUERY" default:"facts[certname, value] { name='ipaddress' and nodes { deactivated is null } }"`
+	Port        	int    `short:"p" long:"collectd-port" description:"Collectd port." env:"PROMETHEUS_PUPPETDB_COLLECTD_PORT" default:"9103"`
+	ConfigDir   	string `short:"c" long:"config-dir" description:"Prometheus config dir." env:"PROMETHEUS_CONFIG_DIR" default:"/etc/prometheus"`
+	File        	string `short:"f" long:"config-file" description:"Prometheus target file." env:"PROMETHEUS_PUPPETDB_FILE" default:"/etc/prometheus/targets/prometheus-puppetdb/targets.yml"`
+	Sleep       	string `short:"s" long:"sleep" description:"Sleep time between queries." env:"PROMETHEUS_PUPPETDB_SLEEP" default:"5s"`
+	Manpage     	bool   `short:"m" long:"manpage" description:"Output manpage."`
 }
 
 type Node struct {
@@ -65,7 +71,31 @@ func main() {
 		os.Exit(1)
 	}
 
-	client := &http.Client{}
+	// Load client cert
+	cert, err := tls.LoadX509KeyPair(cfg.CertFile, cfg.KeyFile)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	// Load CA cert
+	caCert, err := ioutil.ReadFile(cfg.CACertFile)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM(caCert)
+
+	// Setup HTTPS client
+	tlsConfig := &tls.Config{
+					Certificates: 			[]tls.Certificate{cert},
+					RootCAs:      			caCertPool,
+					InsecureSkipVerify: cfg.SSLSkipVerify,
+	}
+	tlsConfig.BuildNameToCertificate()
+	transport := &http.Transport{TLSClientConfig: tlsConfig}
+	client := &http.Client{Transport: transport}
 
 	for {
 		nodes, err := getNodes(client, cfg.PuppetDBURL, cfg.Query)

--- a/main.go
+++ b/main.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"bytes"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"crypto/tls"
-	"crypto/x509"
 	"os"
 	"strings"
 	"time"
@@ -20,18 +20,18 @@ import (
 var version = "undefined"
 
 type Config struct {
-	Version     	bool   `short:"V" long:"version" description:"Display version."`
-	PuppetDBURL 	string `short:"u" long:"puppetdb-url" description:"PuppetDB base URL." env:"PROMETHEUS_PUPPETDB_URL" default:"http://puppetdb:8080"`
-	CertFile			string `short:"x" long:"cert-file" description:"A PEM eoncoded certificate file." env:"PROMETHEUS_CERT_FILE" default:"certs/client.pem"`
-	KeyFile				string `short:"y" long:"key-file" description:"A PEM eoncoded private key file." env:"PROMETHEUS_KEY_FILE" default:"certs/client.key"`
-	CACertFile		string `short:"z" long:"cacert-file" description:"A PEM eoncoded CA's certificate file." env:"PROMETHEUS_CACERT_FILE" default:"certs/cacert.pem"`
-	SSLSkipVerify	bool   `short:"k" long:"ssl-skip-verify" description:"Skip SSL verification." env:"PROMETHEUS_SSL_SKIP_VERIFY"`
-	Query       	string `short:"q" long:"puppetdb-query" description:"PuppetDB query." env:"PROMETHEUS_PUPPETDB_QUERY" default:"facts[certname, value] { name='ipaddress' and nodes { deactivated is null } }"`
-	Port        	int    `short:"p" long:"collectd-port" description:"Collectd port." env:"PROMETHEUS_PUPPETDB_COLLECTD_PORT" default:"9103"`
-	ConfigDir   	string `short:"c" long:"config-dir" description:"Prometheus config dir." env:"PROMETHEUS_CONFIG_DIR" default:"/etc/prometheus"`
-	File        	string `short:"f" long:"config-file" description:"Prometheus target file." env:"PROMETHEUS_PUPPETDB_FILE" default:"/etc/prometheus/targets/prometheus-puppetdb/targets.yml"`
-	Sleep       	string `short:"s" long:"sleep" description:"Sleep time between queries." env:"PROMETHEUS_PUPPETDB_SLEEP" default:"5s"`
-	Manpage     	bool   `short:"m" long:"manpage" description:"Output manpage."`
+	Version       bool   `short:"V" long:"version" description:"Display version."`
+	PuppetDBURL   string `short:"u" long:"puppetdb-url" description:"PuppetDB base URL." env:"PROMETHEUS_PUPPETDB_URL" default:"http://puppetdb:8080"`
+	CertFile      string `short:"x" long:"cert-file" description:"A PEM eoncoded certificate file." env:"PROMETHEUS_CERT_FILE" default:"certs/client.pem"`
+	KeyFile       string `short:"y" long:"key-file" description:"A PEM eoncoded private key file." env:"PROMETHEUS_KEY_FILE" default:"certs/client.key"`
+	CACertFile    string `short:"z" long:"cacert-file" description:"A PEM eoncoded CA's certificate file." env:"PROMETHEUS_CACERT_FILE" default:"certs/cacert.pem"`
+	SSLSkipVerify bool   `short:"k" long:"ssl-skip-verify" description:"Skip SSL verification." env:"PROMETHEUS_SSL_SKIP_VERIFY"`
+	Query         string `short:"q" long:"puppetdb-query" description:"PuppetDB query." env:"PROMETHEUS_PUPPETDB_QUERY" default:"facts[certname, value] { name='ipaddress' and nodes { deactivated is null } }"`
+	Port          int    `short:"p" long:"collectd-port" description:"Collectd port." env:"PROMETHEUS_PUPPETDB_COLLECTD_PORT" default:"9103"`
+	ConfigDir     string `short:"c" long:"config-dir" description:"Prometheus config dir." env:"PROMETHEUS_CONFIG_DIR" default:"/etc/prometheus"`
+	File          string `short:"f" long:"config-file" description:"Prometheus target file." env:"PROMETHEUS_PUPPETDB_FILE" default:"/etc/prometheus/targets/prometheus-puppetdb/targets.yml"`
+	Sleep         string `short:"s" long:"sleep" description:"Sleep time between queries." env:"PROMETHEUS_PUPPETDB_SLEEP" default:"5s"`
+	Manpage       bool   `short:"m" long:"manpage" description:"Output manpage."`
 }
 
 type Node struct {
@@ -89,9 +89,9 @@ func main() {
 
 	// Setup HTTPS client
 	tlsConfig := &tls.Config{
-					Certificates: 			[]tls.Certificate{cert},
-					RootCAs:      			caCertPool,
-					InsecureSkipVerify: cfg.SSLSkipVerify,
+		Certificates:       []tls.Certificate{cert},
+		RootCAs:            caCertPool,
+		InsecureSkipVerify: cfg.SSLSkipVerify,
 	}
 	tlsConfig.BuildNameToCertificate()
 	transport := &http.Transport{TLSClientConfig: tlsConfig}
@@ -248,7 +248,7 @@ func writeNodes(nodes []Node, overrides map[string]map[string]interface{}, port 
 				targets.Labels = map[string]string{
 					"job":      "collectd",
 					"certname": node.Certname,
-					"host": node.Certname,
+					"host":     node.Certname,
 				}
 
 				d, err := yaml.Marshal([]Targets{targets})
@@ -267,7 +267,7 @@ func writeNodes(nodes []Node, overrides map[string]map[string]interface{}, port 
 				targets.Labels = map[string]string{
 					"job":      "collectd",
 					"certname": node.Certname,
-					"host": node.Certname,
+					"host":     node.Certname,
 				}
 				allTargets = append(allTargets, targets)
 			}
@@ -277,7 +277,7 @@ func writeNodes(nodes []Node, overrides map[string]map[string]interface{}, port 
 			targets.Labels = map[string]string{
 				"job":      "collectd",
 				"certname": node.Certname,
-				"host": node.Certname,
+				"host":     node.Certname,
 			}
 			allTargets = append(allTargets, targets)
 		}

--- a/main.go
+++ b/main.go
@@ -24,9 +24,9 @@ var transport *http.Transport
 type Config struct {
 	Version       bool   `short:"V" long:"version" description:"Display version."`
 	PuppetDBURL   string `short:"u" long:"puppetdb-url" description:"PuppetDB base URL." env:"PROMETHEUS_PUPPETDB_URL" default:"http://puppetdb:8080"`
-	CertFile      string `short:"x" long:"cert-file" description:"A PEM eoncoded certificate file." env:"PROMETHEUS_CERT_FILE" default:"certs/client.pem"`
-	KeyFile       string `short:"y" long:"key-file" description:"A PEM eoncoded private key file." env:"PROMETHEUS_KEY_FILE" default:"certs/client.key"`
-	CACertFile    string `short:"z" long:"cacert-file" description:"A PEM eoncoded CA's certificate file." env:"PROMETHEUS_CACERT_FILE" default:"certs/cacert.pem"`
+	CertFile      string `short:"x" long:"cert-file" description:"A PEM encoded certificate file." env:"PROMETHEUS_CERT_FILE" default:"certs/client.pem"`
+	KeyFile       string `short:"y" long:"key-file" description:"A PEM encoded private key file." env:"PROMETHEUS_KEY_FILE" default:"certs/client.key"`
+	CACertFile    string `short:"z" long:"cacert-file" description:"A PEM encoded CA's certificate file." env:"PROMETHEUS_CACERT_FILE" default:"certs/cacert.pem"`
 	SSLSkipVerify bool   `short:"k" long:"ssl-skip-verify" description:"Skip SSL verification." env:"PROMETHEUS_SSL_SKIP_VERIFY"`
 	Query         string `short:"q" long:"puppetdb-query" description:"PuppetDB query." env:"PROMETHEUS_PUPPETDB_QUERY" default:"facts[certname, value] { name='ipaddress' and nodes { deactivated is null } }"`
 	Port          int    `short:"p" long:"collectd-port" description:"Collectd port." env:"PROMETHEUS_PUPPETDB_COLLECTD_PORT" default:"9103"`

--- a/prometheus-puppetdb.1
+++ b/prometheus-puppetdb.1
@@ -1,4 +1,4 @@
-.TH prometheus-puppetdb 1 "13 June 2017"
+.TH prometheus-puppetdb 1 "15 January 2018"
 .SH NAME
 prometheus-puppetdb \- Prometheus scrape lists based on PuppetDB
 .SH SYNOPSIS
@@ -13,6 +13,18 @@ Display version.
 .TP
 \fB\fB\-u\fR, \fB\-\-puppetdb-url\fR <default: \fI"http://puppetdb:8080"\fR>\fP
 PuppetDB base URL.
+.TP
+\fB\fB\-x\fR, \fB\-\-cert-file\fR <default: \fI"certs/client.pem"\fR>\fP
+A PEM eoncoded certificate file.
+.TP
+\fB\fB\-y\fR, \fB\-\-key-file\fR <default: \fI"certs/client.key"\fR>\fP
+A PEM eoncoded private key file.
+.TP
+\fB\fB\-z\fR, \fB\-\-cacert-file\fR <default: \fI"certs/cacert.pem"\fR>\fP
+A PEM eoncoded CA's certificate file.
+.TP
+\fB\fB\-k\fR, \fB\-\-ssl-skip-verify\fR <default: \fI$PROMETHEUS_SSL_SKIP_VERIFY\fR>\fP
+Skip SSL verification.
 .TP
 \fB\fB\-q\fR, \fB\-\-puppetdb-query\fR <default: \fI"facts[certname, value] { name='ipaddress' and nodes { deactivated is null } }"\fR>\fP
 PuppetDB query.


### PR DESCRIPTION
This PR addresses #3 

Introducing three new options to specify Client certificate, Client private Key and CA's Certificate:
`short:"x" long:"cert-file" description:"A PEM eoncoded certificate file."`
`short:"y" long:"key-file" description:"A PEM eoncoded private key file."`
`short:"z" long:"cacert-file" description:"A PEM eoncoded CA's certificate file."`

As well as an option to skip SSL Verification (i.e. curl's `-k`) - this should be used with caution of course.